### PR TITLE
add sqlite schema example...

### DIFF
--- a/mod_conf_sql.html
+++ b/mod_conf_sql.html
@@ -108,6 +108,27 @@ Example PostgresQL schema:
     ctx_id INTEGER NOT NULL
   );
 </pre>
+Example SQLite schema:
+<pre>
+  CREATE TABLE IF NOT EXISTS ftpctx (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_id INTEGER UNSIGNED,
+    name TEXT,
+    type TEXT,
+    value TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS ftpconf (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    value BLOB
+  );
+
+  CREATE TABLE IF NOT EXISTS ftpmap (
+    conf_id INTEGER UNSIGNED NOT NULL,
+    ctx_id INTEGER UNSIGNED NOT NULL
+  );
+</pre>
 Each context and configuration directive is assigned a unique ID.  The
 <code>ftpmap</code> table maps the configuration directive to its appropriate
 context by IDs.  In addition, each context has a parent context, which


### PR DESCRIPTION
in documentation at https://htmlpreview.github.io/?https://github.com/Castaglia/proftpd-mod_conf_sql/blob/master/mod_conf_sql.html you don't have sqlite schema example, but seem to exist her: https://github.com/Castaglia/proftpd-mod_conf_sql/blob/master/sqlite-conf.sql.